### PR TITLE
Execute tasks on background thread

### DIFF
--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -1,6 +1,7 @@
 package com.ocetnik.timer;
 
 import android.os.Handler;
+import android.os.HandlerThread;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -12,9 +13,13 @@ import java.lang.Runnable;
 
 public class BackgroundTimerModule extends ReactContextBaseJavaModule {
 
+    private HandlerThread handlerThread;
     private Handler handler;
     private ReactContext reactContext;
     private Runnable runnable;
+
+    private static final String TIMER_NAME = "timer_name";
+    private static final String TIMEOUT_NAME = "timeout_name";
 
     public BackgroundTimerModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -28,7 +33,9 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void start(final int delay) {
-        handler = new Handler();
+        handlerThread = new HandlerThread(TIMER_NAME);
+        handlerThread.start();
+        handler = new Handler(handlerThread.getLooper());
         runnable = new Runnable() {
             @Override
             public void run() {
@@ -54,16 +61,18 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setTimeout(final int id, final int timeout) {
-        Handler handler = new Handler();
-        handler.postDelayed(new Runnable(){
+        HandlerThread handlerThread = new HandlerThread(TIMEOUT_NAME);
+        handlerThread.start();
+        Handler handler = new Handler(handlerThread.getLooper());
+        handler.postDelayed(new Runnable() {
             @Override
-            public void run(){
+            public void run() {
                 if (getReactApplicationContext().hasActiveCatalystInstance()) {
                     getReactApplicationContext()
                         .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                         .emit("backgroundTimer.timeout", id);
                 }
-           }
+            }
         }, timeout);
     }
 


### PR DESCRIPTION
This fixes issue https://github.com/ocetnik/react-native-background-timer/issues/15 for Android.