### PR TITLE
Mark tasks as ended in iOS

### DIFF
--- a/ios/RNBackgroundTimer.m
+++ b/ios/RNBackgroundTimer.m
@@ -73,6 +73,7 @@ RCT_EXPORT_METHOD(setTimeout:(int)timeoutId
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeout * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
         [self.bridge.eventDispatcher sendDeviceEventWithName:@"backgroundTimer.timeout" body:[NSNumber numberWithInt:timeoutId]];
+        [[UIApplication sharedApplication] endBackgroundTask:task];
     });
     resolve([NSNumber numberWithBool:YES]);
 }


### PR DESCRIPTION
If all tasks are left to expire, the log gets flooded with lines such
as:

HWM increased to 2844 because of <BKProcessAssertion: 0x1003b5930;
"RNBackgroundTimer" (finishTask:180s); id:…DDE933B1E7D6>

And after a prolonger period of time the device completely freezes /
resprings.