### PR TITLE
Address deprecation warnings. Update main event emitter to NativeEventEmitter.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 import {
 	NativeModules,
-	DeviceEventEmitter
+	NativeEventEmitter
 } from 'react-native';
 
-const RNBackgroundTimer = NativeModules.RNBackgroundTimer;
+const { RNBackgroundTimer } = NativeModules;
+const Emitter = new NativeEventEmitter(RNBackgroundTimer);
 
 class BackgroundTimer {
 
@@ -11,7 +12,7 @@ class BackgroundTimer {
 		this.uniqueId = 0;
 		this.callbacks = {};
 
-		DeviceEventEmitter.addListener('backgroundTimer.timeout', (id) => {
+		Emitter.addListener('backgroundTimer.timeout', (id) => {
 			if (this.callbacks[id]) {
 				const callback = this.callbacks[id].callback;
 				if (!this.callbacks[id].interval) {

--- a/ios/RNBackgroundTimer.h
+++ b/ios/RNBackgroundTimer.h
@@ -7,7 +7,8 @@
 //
 
 #import <React/RCTBridgeModule.h>
+#import "RCTEventEmitter.h"
 
-@interface RNBackgroundTimer : NSObject <RCTBridgeModule>
+@interface RNBackgroundTimer : RCTEventEmitter <RCTBridgeModule>
 
 @end


### PR DESCRIPTION
Hello!

I've addressed a bunch of deprecation warnings. This PR resolves #42.

React Native throws the warning:
> `sendDeviceEventWithName:body:` is deprecated: Subclass RCTEventEmitter instead.

So, I've gone ahead and updated the primary event emitter (RCTEventDispatcher) with RCTEventEmitter. This involved some changes on the index.js file so look through that as well.

Another warning:
> RNBackgroundTimer.m:35:114: Implicit conversion loses integer precision: 'const UIBackgroundTaskIdentifier' (aka 'const unsigned long') to 'int'

I casted the `timeoutId` argument with `int`since that was already being done.

Finally, another warning: 
> RNBackgroundTimer.m:70:141: Variable 'task' is uninitialized when captured by block

I simply had to add __block in front of the task variable. More details on that [here](https://stackoverflow.com/questions/7080927/what-does-the-block-keyword-mean).

Please let me know if any other changes are needed! I'd love to get this merged in soon as we are about to ship our app and no warnings would be a good feeling. 🙂
