### PR TITLE
Prevent the crash of "bridge not set" until a fix is set on react nat…

### DIFF
--- a/ios/RNBackgroundTimer.m
+++ b/ios/RNBackgroundTimer.m
@@ -30,7 +30,7 @@ RCT_EXPORT_MODULE()
 
     UIBackgroundTaskIdentifier thisBgTask = bgTask;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
-        if (thisBgTask == bgTask) {
+        if ([self bridge] != nil && thisBgTask == bgTask) {
             [self sendEventWithName:@"backgroundTimer" body:[NSNumber numberWithInt:(int)thisBgTask]];
             [self _start];
         }
@@ -71,7 +71,9 @@ RCT_EXPORT_METHOD(setTimeout:(int)timeoutId
     }];
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeout * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
-        [self sendEventWithName:@"backgroundTimer.timeout" body:[NSNumber numberWithInt:timeoutId]];
+        if ([self bridge] != nil) {
+            [self sendEventWithName:@"backgroundTimer.timeout" body:[NSNumber numberWithInt:timeoutId]];
+        }
         [[UIApplication sharedApplication] endBackgroundTask:task];
     });
     resolve([NSNumber numberWithBool:YES]);


### PR DESCRIPTION
Prevent the crash of "bridge not set" until a fix is set on **react native.**
Related issue: https://github.com/ocetnik/react-native-background-timer/issues/47