### PR TITLE
Fix for iOS background timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,36 @@ Emit event periodically (even when app is in the background).
 - `npm i react-native-background-timer --save`
 - add the following to your Podfile: `pod 'react-native-background-timer', :path => '../node_modules/react-native-background-timer'`
 
-## Usage
+## Usage Crossplatform
+To use the same code both on Android and iOS use runBackgroundTimer() and stopBackgroundTimer(). There can be used only one background timer to keep code consistent.
+
+```javascript
+BackgroundTimer.runBackgroundTimer(() => { 
+//code that will be called every 3 seconds 
+}, 
+3000);
+//rest of code will be performing for iOS on background too
+
+BackgroundTimer.stopBackgroundTimer(); //after this call all code on background stop run.
+```
+> Android didn't tested as well.
+
+## Usage iOS
+After iOS update logic of background task little bit changed. So we can't use as it was. 
+You have to use only start() and stop() without parameters. And all code that is performing will continue performing on background including all setTimeout() timers.
+
+Example:
+```javascript
+BackgroundTimer.start();
+// Do whatever you want incuding setTimeout;
+BackgroundTimer.stop();
+```
+
+> If you call stop() on background no new tasks will be started!
+> Don't call .start() twice, as it stop performing previous background task and starts new. 
+> If it will be called on backgound no tasks will run.
+
+## Usage Android
 You can use the `setInterval` and `setTimeout` functions.
 This API is identical to that of `react-native` and can be used to quickly replace existing timers
 with background timers.
@@ -64,13 +93,12 @@ const EventEmitter = Platform.select({
 
 ```js
 // start a global timer
-BackgroundTimer.start(5000); // delay in milliseconds
+BackgroundTimer.start(5000); // delay in milliseconds only for Android
 ```
 ```js
 // listen for event
 EventEmitter.addListener('backgroundTimer', () => {
-	// this will be executed every 5 seconds
-	// even when app is the the background
+	// this will be executed once after 5 seconds
 	console.log('toe');
 });
 ```

--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -33,7 +33,6 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
             @Override
             public void run() {
                 sendEvent(reactContext, "backgroundTimer");
-                handler.postDelayed(runnable, delay);
             }
         };
 

--- a/ios/RNBackgroundTimer.m
+++ b/ios/RNBackgroundTimer.m
@@ -29,12 +29,14 @@ RCT_EXPORT_MODULE()
     }];
 
     UIBackgroundTaskIdentifier thisBgTask = bgTask;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
-        if ([self bridge] != nil && thisBgTask == bgTask) {
-            [self sendEventWithName:@"backgroundTimer" body:[NSNumber numberWithInt:(int)thisBgTask]];
-            [self _start];
-        }
-    });
+    while([self bridge] != nil && thisBgTask == bgTask) {
+        [NSThread sleepForTimeInterval:delay/1000.f];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if ([self bridge] != nil && thisBgTask == bgTask) {
+                [self sendEventWithName:@"backgroundTimer" body:[NSNumber numberWithInt:(int)thisBgTask]];
+            }
+        });
+    }
 }
 
 - (void) _stop

--- a/ios/RNBackgroundTimer.m
+++ b/ios/RNBackgroundTimer.m
@@ -27,16 +27,13 @@ RCT_EXPORT_MODULE()
         [[UIApplication sharedApplication] endBackgroundTask:bgTask];
         bgTask = UIBackgroundTaskInvalid;
     }];
-
+    
     UIBackgroundTaskIdentifier thisBgTask = bgTask;
-    while([self bridge] != nil && thisBgTask == bgTask) {
-        [NSThread sleepForTimeInterval:delay/1000.f];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if ([self bridge] != nil && thisBgTask == bgTask) {
-                [self sendEventWithName:@"backgroundTimer" body:[NSNumber numberWithInt:(int)thisBgTask]];
-            }
-        });
-    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([self bridge] != nil && thisBgTask == bgTask) {
+            [self sendEventWithName:@"backgroundTimer" body:[NSNumber numberWithInt:(int)thisBgTask]];
+        }
+    });
 }
 
 - (void) _stop

--- a/ios/RNBackgroundTimer.xcodeproj/xcuserdata/jlexyc.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ios/RNBackgroundTimer.xcodeproj/xcuserdata/jlexyc.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>RNBackgroundTimer-tvOS.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>42</integer>
+		</dict>
+		<key>RNBackgroundTimer.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>41</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
iOS background task can't be recreated in background. So here fix for iOS and additional API to use the same code for Android and iOS.

Actually we need to revisit general concept of this library in future. But for now it does work.

Fixes issues:
#46
#54
