### PR TITLE
podspec: Add React dependency

### DIFF
--- a/react-native-background-timer.podspec
+++ b/react-native-background-timer.podspec
@@ -19,4 +19,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
+  s.dependency 'React'
+
 end


### PR DESCRIPTION
Depending on which modules are built and in which order, `React/RCTBridgeModule.h` may or may not be available. Some workarounds for this include disabling parallel builds (https://stackoverflow.com/a/43340802), manually linking against the library instead of using cocoapods (https://github.com/ocetnik/react-native-background-timer/issues/87#issuecomment-401594083), changing the way source files are imported (https://stackoverflow.com/a/41664041), and some others. These workarounds appear to fundamentally disregard the actual problem, which is that these React Native packages all depend on React, and need to be built after the React package has been built. So let's describe this dependency so the build system can solve the issue for us consistently.

Another example of this same issue/fix with another React Native package can be found [here](https://github.com/charlires/react-native-segment-analytics/pull/33).

Fixes #87.