### PR TITLE
Check WakeLock is being held, before release.

### DIFF
--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -31,7 +31,7 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
 
         @Override
         public void onHostDestroy() {
-            wakeLock.release();
+            if (wakeLock.isHeld()) wakeLock.release();
         }
     };
 


### PR DESCRIPTION
Check WakeLock is being held, before release it.
This will fix **java.lang.RuntimeException: WakeLock under-locked**.