### PR TITLE
Update README.md with Android manual linking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,41 @@ Emit event periodically (even when app is in the background).
 - `yarn add react-native-background-timer`
 - add the following to your Podfile: `pod 'react-native-background-timer', :path => '../node_modules/react-native-background-timer'`
 
+### Manual linking on Android
+
+Apply these changes to your project if `react-native link react-native-background-timer` failed:
+
+**`android/settings.gradle`:**
+
+```
+include ':react-native-background-timer'
+project(':react-native-background-timer').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-background-timer/android')
+```
+
+**`android/app/src/main/java/com/yourproject/MainApplication.java`:**
+
+On top, where imports are:
+```
+import com.ocetnik.timer.BackgroundTimerPackage;
+```
+Add BackgroundTimerPackage() to the list of exported packages:
+```
+    @Override
+    protected List<ReactPackage> getPackages() {
+      return Arrays.<ReactPackage>asList(
+            ...
+            new BackgroundTimerPackage()
+      );
+    }
+```
+**`android/app/build.gradle`:**
+```
+dependencies {
+    ...
+    implementation project(':react-native-background-timer')
+}
+```
+
 ## Usage Crossplatform
 To use the same code both on Android and iOS use runBackgroundTimer() and stopBackgroundTimer(). There can be used only one background timer to keep code consistent.
 


### PR DESCRIPTION
Adding "Android manual linking instructions" for cases where `react-native link` doesn't work (https://github.com/ocetnik/react-native-background-timer/issues/113)