### PR TITLE
Only use wakelocks on Android when the timer is in use

### DIFF
--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -21,13 +21,10 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
     private PowerManager.WakeLock wakeLock;
     private final LifecycleEventListener listener = new LifecycleEventListener(){
         @Override
-        public void onHostResume() {
-            wakeLock.acquire();
-        }
+        public void onHostResume() {}
+
         @Override
-        public void onHostPause() {
-            //wakeLock.release();
-        }
+        public void onHostPause() {}
 
         @Override
         public void onHostDestroy() {
@@ -50,6 +47,8 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void start(final int delay) {
+        if (!wakeLock.isHeld()) wakeLock.acquire();
+
         handler = new Handler();
         runnable = new Runnable() {
             @Override
@@ -63,6 +62,8 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void stop() {
+        if (wakeLock.isHeld()) wakeLock.release();
+
         // avoid null pointer exceptio when stop is called without start
         if (handler != null) handler.removeCallbacks(runnable);
     }


### PR DESCRIPTION
This PR changes the behaviour on Android to only use wakelocks when the timer is actually in use.

Currently the wakelock is acquired when the app starts up, and is held until it is closed. As mentioned in #109, this can cause significant increases in battery usage, even when the timer isn't actually being used.

This PR changes this so that the wakelock is acquired when `start` is called, and released when `stop` is called. I believe this behaviour is much more efficient, and shouldn't affect how the background timer works at all.