### PR TITLE
Increase `timeout` Parameter to Accept 64-bit Integers for Larger Timeouts

### DIFF
--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -86,7 +86,7 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
                         .emit("backgroundTimer.timeout", id);
                 }
            }
-        }, timeout);
+        }, (long) timeout);
     }
 
     /*@ReactMethod

--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -75,7 +75,7 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setTimeout(final int id, final int timeout) {
+    public void setTimeout(final int id, final double timeout) {
         Handler handler = new Handler();
         handler.postDelayed(new Runnable(){
             @Override

--- a/ios/RNBackgroundTimer.m
+++ b/ios/RNBackgroundTimer.m
@@ -44,7 +44,7 @@ RCT_EXPORT_MODULE()
     }
 }
 
-RCT_EXPORT_METHOD(start:(int)_delay
+RCT_EXPORT_METHOD(start:(double)_delay
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -61,7 +61,7 @@ RCT_EXPORT_METHOD(stop:(RCTPromiseResolveBlock)resolve
 }
 
 RCT_EXPORT_METHOD(setTimeout:(int)timeoutId
-                     timeout:(int)timeout
+                     timeout:(double)timeout
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-timer",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Emit event periodically (even when app is in the background)",
   "keywords": [
     "react-native",


### PR DESCRIPTION
The `int` primitive in Java is a 32-bit signed integer which supports integers ranging from `-2147483648` to `2147483647`, inclusively. In my app however, I require passing integers _larger_ than the upper bound, i.e. `2591984761`. Updating the `setTimeout(int timeoutId, int timeout)` signature to `setTimeout(int timeoutId, double timeout)` would address this issue. 