### PR TITLE
Add support for RN headers in both namespaces

### DIFF
--- a/ios/RNBackgroundTimer.h
+++ b/ios/RNBackgroundTimer.h
@@ -7,7 +7,14 @@
 //
 
 #import <React/RCTBridgeModule.h>
+// Support React Native headers both in the React namespace, where they are in RN version 0.40+,
+// and no namespace, for older versions of React Native
+#if __has_include(<React/RCTEventEmitter.h>)
+#import <React/RCTEventEmitter.h>
+#else
 #import "RCTEventEmitter.h"
+#endif
+
 
 @interface RNBackgroundTimer : RCTEventEmitter <RCTBridgeModule>
 


### PR DESCRIPTION
Fixes #67 

Support RN headers both in the React namespace,
where they are in RN version 0.40+,
and no namespace, for older versions of RN