### PR TITLE
fixed warnings 'new NativeEventEmitter() was called with a non-null a…

### DIFF
--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -89,6 +89,16 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
         }, (long) timeout);
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     /*@ReactMethod
     public void clearTimeout(final int id) {
         // todo one day..


### PR DESCRIPTION
…rgument without the required addListener and removeListener methods' on react-native 0.65 and android platform