### PR TITLE
Fix warning new NativeEventEmitter()  called without...

### DIFF
--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -89,6 +89,16 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
         }, (long) timeout);
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     /*@ReactMethod
     public void clearTimeout(final int id) {
         // todo one day..


### PR DESCRIPTION
Fix the warning `new NativeEventEmitter() was called with a non-null argument without the required addListener and removeListener methods` 

Closes #359 
Closes #366
Closes #367

Original patch source: https://stackoverflow.com/a/69650217/7732434

For those wanting this fix, instead of waiting for a merge, you can install the fork

`yarn add react-native-background-timer@https://github.com/Spltthetnk/react-native-background-timer`

Hopefully someone can fix the iOS warnings that probably exist (I'm on Windows, so I don't know).

Be sure to check out SplitTheTank (https://splitthetank.com) in the near future. 💙💜