### PR TITLE
Update Android wake lock tag to include required colon

### DIFF
--- a/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
+++ b/android/src/main/java/com/ocetnik/timer/BackgroundTimerModule.java
@@ -36,7 +36,7 @@ public class BackgroundTimerModule extends ReactContextBaseJavaModule {
         super(reactContext);
         this.reactContext = reactContext;
         this.powerManager = (PowerManager) getReactApplicationContext().getSystemService(reactContext.POWER_SERVICE);
-        this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "rohit_bg_wakelock");
+        this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "react-native-background-timer:wakelock");
         reactContext.addLifecycleEventListener(listener);
     }
 


### PR DESCRIPTION
From the [documentation](https://developer.android.com/reference/android/os/PowerManager#newWakeLock(int,%20java.lang.String)):

> use a unique prefix delimited by a colon for your app/library (e.g. gmail:mytag) to make it easier to understand where the wake locks comes from.

It sounds like just a recommendation, but the linter error actually causes a build failure.